### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/jrh3k5/moo4plex/security/code-scanning/1](https://github.com/jrh3k5/moo4plex/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow does not require write access to repository contents or other resources, the permissions can be limited to `contents: read`. This ensures the `GITHUB_TOKEN` has only the minimal privileges necessary to complete the tasks in the workflow.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
